### PR TITLE
Added resourceAttributeInternalText to Emergency Resource Type

### DIFF
--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -729,6 +729,12 @@ components:
                 registry
               items:
                 type: string
+            resourceAttributeInternalText:
+              type: array
+              description: 
+                A local code for an emergency resource attribute.  Must be populated if the resourceAttributeRegistryText is set to 'Other'
+                items:
+                  type: string
             emergencyResourceName:
               type: string
               description:


### PR DESCRIPTION
The new resourceAttributeInternalText was added to the EIDO JSON schema file.