### PR TITLE
Corrected alternate value issues

### DIFF
--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -67,7 +67,7 @@ components:
           description:
             A globally unique identifier of the agent or automaton that updated
             the data component last
-        alternateValueReferences:
+        alternateValuesReferences:
           type: array
           description: References to alternate values data component. Alternate values for data elements in this data component.
           items:

--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -125,7 +125,6 @@ components:
             required:
               - constituent
               - timeStamp
-              - otherValue
             properties:
               constituent:
                 type: string
@@ -135,10 +134,9 @@ components:
                 format: date-time
                 description: TimeStamp of Data Component 
               otherValue:
-                type: string
+                type: object
                 description: 
                   Value for this element sent by constituent
-                  If the element is complex (array or object), the value is the JSON representation of the element. 
     AgencyType:
       title: Agency Type
       description:

--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -67,7 +67,7 @@ components:
           description:
             A globally unique identifier of the agent or automaton that updated
             the data component last
-        AlternateValueReferences:
+        alternateValueReferences:
           type: array
           description: References to alternate values data component. Alternate values for data elements in this data component.
           items:


### PR DESCRIPTION
Corrected the following:

- otherValue is no longer a required attribute of Alternate Value Type
- Alternate Value Type otherValue attribute is now defined as an object instead of a string