### PR TITLE
NENA STA 021.1.1 General Fixes

### DIFF
--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -72,14 +72,14 @@ components:
           description: References to alternate values data component. Alternate values for data elements in this data component.
           items:
             $ref: '#/components/schemas/ReferenceType'
-        externalInformationSourceReferences:
+        externalInformationSourceReference:
           type: array
           items:
             $ref: '#/components/schemas/ReferenceType'
           description:
             References to External Sources Data Components that are links to external
             information sources not otherwise defined in the EIDO.
-        mediaReferences: 
+        mediaReference: 
           type: array
           items:
             $ref: '#/components/schemas/ReferenceType'

--- a/Schema/openapi.yaml
+++ b/Schema/openapi.yaml
@@ -1540,7 +1540,27 @@ components:
               type: array
               description: All conflicting values not chosen by the IDX coalescing algorithm are listed here.
               items:
-                $ref: '#/components/schemas/AlternateValuesType'                
+                $ref: '#/components/schemas/AlternateValuesType'
+            itemComponent:
+              type: array
+              description:
+            	All item information referenced in this document are listed here. 
+              items:
+            	$ref: '#/components/schemas/ItemInformationType'	
+            
+            organizationComponent:
+              type: array
+              description:
+            	All organization information referenced in this document are listed here. 
+              items:
+            	$ref: '#/components/schemas/OrganizationInformationType'	
+            
+            unitEmergencyStateComponent:
+              type: array
+              description:
+            	All unit emergency state information referenced in this document are listed here. 
+              items:
+            	$ref: '#/components/schemas/UnitEmergencyStateType'                
             '@context':
               type: object
               description: JSON-LD context


### PR DESCRIPTION
The following properties were added to the `EmergencyIncidentDataObject`:

- itemComponent
- organizationComponent
- unitEmergencyStateComponent

The following reference arrays were renamed to be consistent with existing naming conventions:

- externalInformationSourceReferences -> externalInformationSourceReference
- mediaReferences -> mediaReference